### PR TITLE
Rework README.md to be up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,35 @@
-[![Build Status](https://travis-ci.org/RedHatInsights/registration-assistant.svg?branch=master)](https://travis-ci.org/RedHatInsights/registration-assistant)
+[![Build Status](https://api.travis-ci.com/RedHatInsights/registration-assistant.svg?branch=master)](https://www.travis-ci.com/github/RedHatInsights/registration-assistant)
 
 # registration-assistant
-
 React.js registration-assistant app for Red Hat Insights provides an in-application interactive experience which helps guide the user through the registration process to get the Red Hat Insights client installed and registered on their systems. We believe by nurturing the customer through the process and providing a clear call to action around installation within the applications, we can help drive additional adoption increasing the breadth of Insights registrations for an account.
 
-## Getting Started
+## First time setup
+1. Make sure you have [Node.js](https://nodejs.org/en/) version >14 installed
+2. Run [script to patch your `/etc/hosts`](https://github.com/RedHatInsights/insights-proxy/blob/master/scripts/patch-etc-hosts.sh)
+3. Make sure you are using [Red Hat proxy](http://hdn.corp.redhat.com/proxy.pac)
 
-There is a [comprehensive quick start guide in the Storybook Documentation](https://github.com/RedHatInsights/insights-frontend-storybook/blob/master/src/docs/welcome/quickStart/DOC.md) to setting up an Insights environment complete with:
+## Running locally
+1. Install dependencies with `npm install`
+2. Run development server with `npm run start:proxy:beta`
+3. Local version of the app will be available at https://stage.foo.redhat.com:1337/beta/insights/registration
 
-- Insights Registration Assistant App
+If you encounter any problems try to consult the [Troubleshooting page](https://docs.engineering.redhat.com/pages/viewpage.action?spaceKey=RHIF&title=Troubleshooting).
 
-- [Insights Chroming](https://github.com/RedHatInsights/insights-chrome)
-- [Insights Proxy](https://github.com/RedHatInsights/insights-proxy)
-
-Note: You will need to set up the Insights environment if you want to develop with the registration assistant app due to the consumption of the chroming service as well as setting up your global/app navigation through the API.
-
-## Build app
-
-1. ```npm install```
-
-2. ```npm run start```
-    - starts webpack bundler and serves the files with webpack dev server
-
-    OR 
-
-2. ```npm run start:proxy```
-  - starts webpack bundler and serves the files with webpack dev server and runs chrome proxy (prod env) (one less terminal required)
-
-3. visit ```https://prod.foo.redhat.com:1337/insights/registration/```
-
-### Testing
-
-- `npm run verify` will run linters and tests
-- Travis is used to test the build for this code.
-  - You are always notified on failed builds
-  - You are only notified on successful builds if the build before it failed
-  - By default, both `push` events as well as `pull_request` events send notifications
-  - Travis is defaulted to notify #insights-bots
+## Testing
+[Jest](https://jestjs.io/) is used as the testing framework, although there are currently no Jest tests present. `npm run verify` will run linters and tests. Travis is used to test the build for this code.
 
 ## Deploying
+Any push to the following branches will trigger a build in [registration-assistant-build repository](https://github.com/RedHatInsights/registration-assistant-build) which will deploy to corresponding environment. Travis is used to deploy the application.
 
-- The Platform team is using Travis to deploy the application
-  - The Platform team will help you set up the Travis instance if this is the route you are wanting to take
+| Push to branch in this repo  | Updated branch in build repo  | Environment       | Available at
+| :--------------------------- | :---------------------------- | :---------------- | :-----------
+| master                       | qa-beta                       | stage beta        | https://console.stage.redhat.com/beta
+| master-stable                | qa-stable                     | stage stable      | https://console.stage.redhat.com
+| prod-beta                    | prod-beta                     | production beta   | https://console.redhat.com/beta 
+| prod-stable                  | prod-stable                   | production stable | https://console.redhat.com
 
-## Running locally (if not using start:proxy script)
-Have [insights-proxy](https://github.com/RedHatInsights/insights-proxy) installed under PROXY_PATH
+## Design System
+This project uses [Patternfly React](https://github.com/patternfly/patternfly-react).
 
-```shell
-SPANDX_CONFIG="./profiles/local-frontend.js" bash $PROXY_PATH/scripts/run.sh
-```
-
-### Testing - jest
-
-When you want to test your code with unit tests please use `jest` which is preconfigured in a way to colect codecoverage as well. If you want to see your coverage on server the travis config has been set in a way that it will send data to [codecov.io](https://codecov.io) the only thing you have to do is visit their website (register), enable your repository and add CODECOV_TOKEN to your travis web config (do not add it to .travis file, but trough [travis-ci.org](https://travis-ci.org/))
+## Insights Components
+This app imports components from [Insights Front-end Components library](https://github.com/RedHatInsights/frontend-components). ESI tags are used to import [Insights Chrome](https://github.com/RedHatInsights/insights-chrome) which takes care of the header, sidebar, and footer. These libraries are described in the [Platform experience documentation](http://front-end-docs-insights.apps.ocp4.prod.psi.redhat.com/).


### PR DESCRIPTION
- Update setup instructions (previously README was describing the old Insights proxy setup)
- Replace old `qaprodauth` env instructions with `stage`
- add links to more docs
- remove paragraphs which were instructing the actual creation of this app (Getting Started, Testing - jest chapters)