### PR TITLE
fix(container): add akamai fe spec

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -14,6 +14,8 @@ objects:
       frontend:
         paths:
           - /apps/registration
+        akamaiCacheBustPaths:
+         - /apps/registration/fed-mods.json
       API:
         versions:
           - v1


### PR DESCRIPTION
 because the route and the frontend name don't match cache busts are done incorrectly. This adds a param to adjust for this 