### PR TITLE
Use consistent name in the frontend resource YAML

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -1,21 +1,16 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: registration-assistant
+  name: registration
 objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: Frontend
     metadata:
-      name: registration-assistant
+      name: registration
     spec:
       envName: ${ENV_NAME}
-      title: registration-assistant
+      title: registration
       deploymentRepo: https://github.com/RedHatInsights/registration-assistant
-      frontend:
-        paths:
-          - /apps/registration
-        akamaiCacheBustPaths:
-         - /apps/registration/fed-mods.json
       API:
         versions:
           - v1


### PR DESCRIPTION
This patch changes all of the definable names in the Frontend resource YAML to `registration` rather than `registration-assistant`. The frontend operator generates a lot of resources based on the resource name: the route API paths, the Akamai cash bust paths, etc. You either have to use a Frontend resource name that matches what all of those things should be in all environments, or you need to manually manage all of it. There's no real benefit to managing it manually, so its easier just to name the resource what you want your routes to be and have it done for you.