### PR TITLE
chore: put the spec.frontend.paths array back

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -11,6 +11,9 @@ objects:
       envName: ${ENV_NAME}
       title: registration
       deploymentRepo: https://github.com/RedHatInsights/registration-assistant
+      frontend:
+        paths:
+          - /apps/registration
       API:
         versions:
           - v1


### PR DESCRIPTION
In the Frontend resource `spec.frontends.paths` is defined as a required field, even if you don't need to override the defaults. Adding it back to make the resource valid.