### PR TITLE
feat(RHINENG-13856): Create progress stepper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@redhat-cloud-services/frontend-components": "^4.2.16",
         "@redhat-cloud-services/frontend-components-translations": "^3.2.8",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.17",
+        "@unleash/proxy-client-react": "^4.4.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-intl": "^6.8.0",
@@ -5234,6 +5235,17 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-4.4.0.tgz",
+      "integrity": "sha512-btU/2Pho5eVOBdIYxNAeHq36lpm41/qmRVKuuLIGdg3XOZign9rA6KsarAk94W01XKulrNCrESINZMIvPoA6Cg==",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "unleash-proxy-client": "^3.5.2"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.12.1",
@@ -18372,6 +18384,12 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "peer": true
+    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
@@ -18988,6 +19006,29 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unleash-proxy-client": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.6.1.tgz",
+      "integrity": "sha512-gbvkob/cBewLHMh9aAwWLDLN8D1efJ5FdUMva7wGBVykJMIqyYIlUsJpVNXnpq+feNBn6Qc1D1huXD2bk9bEmA==",
+      "peer": true,
+      "dependencies": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^9.0.1"
+      }
+    },
+    "node_modules/unleash-proxy-client/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@redhat-cloud-services/frontend-components": "^4.2.16",
     "@redhat-cloud-services/frontend-components-translations": "^3.2.8",
     "@redhat-cloud-services/frontend-components-utilities": "^4.0.17",
+    "@unleash/proxy-client-react": "^4.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-intl": "^6.8.0",

--- a/src/Components/RegistrationProgress/CentosLinuxRegContent.js
+++ b/src/Components/RegistrationProgress/CentosLinuxRegContent.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CentosLinuxRegContent = ({ selectedKey }) => {
+  return (
+    <div>{`CentOS Linux content. Your activation key is ${selectedKey}`}</div>
+  );
+};
+
+CentosLinuxRegContent.propTypes = {
+  selectedKey: PropTypes.string,
+};
+
+export default CentosLinuxRegContent;

--- a/src/Components/RegistrationProgress/FirstStep.js
+++ b/src/Components/RegistrationProgress/FirstStep.js
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Icon,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { InsightsLink } from '@redhat-cloud-services/frontend-components/InsightsLink';
+
+const FirstStep = ({ selectedKey, setSelectedKey, setStep, step }) => {
+  const [isOpen, setOpen] = useState(false);
+
+  const handleActivationKeySelect = (optionName) => {
+    setSelectedKey(optionName);
+    step === 0 && setStep(1);
+    setOpen(false);
+  };
+
+  const toggle = (toggleRef) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      style={{
+        width: 'auto',
+        marginTop: '8px',
+        marginBottom: '8px',
+      }}
+    >
+      {selectedKey}
+    </MenuToggle>
+  );
+
+  return (
+    <React.Fragment>
+      <TextContent>
+        <Text component={TextVariants.p}>
+          You need an{' '}
+          <Text
+            component={TextVariants.a}
+            href="https://docs.redhat.com/en/documentation/subscription_central/1-latest/html/getting_started_with_activation_keys_on_the_hybrid_cloud_console/index"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            activation key
+            <Icon className="pf-v5-u-ml-xs">
+              <ExternalLinkAltIcon />
+            </Icon>
+          </Text>{' '}
+          to register. An activation key is a pre-shared token that enables
+          authorized users to register and auto-configure systems.
+        </Text>
+      </TextContent>
+      <div
+        style={{
+          fontWeight: 'var(--pf-v5-global--FontWeight--bold)',
+          color: '#151515',
+          marginTop: '16px',
+        }}
+        data-testid="select-activation-key"
+      >
+        Activation key <span style={{ color: '#C9190B' }}>*</span>
+      </div>
+      <Select
+        isOpen={isOpen}
+        onSelect={(_, optionName) => handleActivationKeySelect(optionName)}
+        selected={selectedKey}
+        toggle={toggle}
+      >
+        <SelectList>
+          <SelectOption width="100%" value="activation-key-1">
+            activation-key-1
+          </SelectOption>
+          <SelectOption width="100%" value="activation-key-2">
+            activation-key-2
+          </SelectOption>
+        </SelectList>
+      </Select>
+      <TextContent>
+        <Text component={TextVariants.p}>
+          Manage activation keys on the{' '}
+          <InsightsLink to="/activation-keys" app="connector">
+            Activation keys page
+          </InsightsLink>
+        </Text>
+      </TextContent>
+    </React.Fragment>
+  );
+};
+
+FirstStep.propTypes = {
+  selectedKey: PropTypes.string,
+  setSelectedKey: PropTypes.func,
+  setStep: PropTypes.func,
+  step: PropTypes.number,
+};
+
+export default FirstStep;

--- a/src/Components/RegistrationProgress/FourthStep.js
+++ b/src/Components/RegistrationProgress/FourthStep.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Text, TextContent, TextVariants } from '@patternfly/react-core';
+import InsightsLink from '@redhat-cloud-services/frontend-components/InsightsLink';
+
+const FourthStep = () => {
+  return (
+    <React.Fragment>
+      <TextContent>
+        <Text component={TextVariants.p}>
+          Navigate to{' '}
+          <InsightsLink to="/" app="inventory">
+            Inventory page
+          </InsightsLink>
+        </Text>
+        <Text component={TextVariants.p}>
+          Your system could take a couple of minutes to appear.
+        </Text>
+      </TextContent>
+    </React.Fragment>
+  );
+};
+
+export default FourthStep;

--- a/src/Components/RegistrationProgress/RHEL7RegContent.js
+++ b/src/Components/RegistrationProgress/RHEL7RegContent.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RHEL7RegContent = ({ selectedKey }) => {
+  return <div>{`RHEL 7 content. Your activation key is ${selectedKey}`}</div>;
+};
+
+RHEL7RegContent.propTypes = {
+  selectedKey: PropTypes.string,
+};
+
+export default RHEL7RegContent;

--- a/src/Components/RegistrationProgress/RHEL8RegContent.js
+++ b/src/Components/RegistrationProgress/RHEL8RegContent.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RHEL8RegContent = ({ selectedKey }) => {
+  return <div>{`RHEL 8 content. Your activation key is ${selectedKey}`}</div>;
+};
+
+RHEL8RegContent.propTypes = {
+  selectedKey: PropTypes.string,
+};
+
+export default RHEL8RegContent;

--- a/src/Components/RegistrationProgress/RHEL9RegContent.js
+++ b/src/Components/RegistrationProgress/RHEL9RegContent.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const RHEL9RegContent = ({ selectedKey }) => {
+  return <div>{`RHEL 9 content. Your activation key is ${selectedKey}`}</div>;
+};
+
+RHEL9RegContent.propTypes = {
+  selectedKey: PropTypes.string,
+};
+
+export default RHEL9RegContent;

--- a/src/Components/RegistrationProgress/RegAssistantFooter.js
+++ b/src/Components/RegistrationProgress/RegAssistantFooter.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Icon, Text, TextContent, TextVariants } from '@patternfly/react-core';
+import { monitoringHostsLink, remoteHostConfigLink } from '../../constants';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const RegAssistantFooter = () => {
+  return (
+    <TextContent style={{ marginTop: '24px' }}>
+      <Text component={TextVariants.p}>
+        Read more about Remote host configuration (RHC) options and levels of
+        connectivity:{' '}
+        <a
+          rel="noopener noreferrer"
+          target="_blank"
+          href={remoteHostConfigLink}
+        >
+          Remote Host Configuration and Management | Red Hat Product
+          Documentation{' '}
+          <Icon className="pf-v5-u-ml-xs">
+            <ExternalLinkAltIcon />
+          </Icon>
+        </a>
+      </Text>
+      <Text component={TextVariants.p}>
+        Looking for ways to automate with Satellite? Read this article:{' '}
+        <a rel="noopener noreferrer" target="_blank" href={monitoringHostsLink}>
+          Chapter9. Monitoring Hosts Using Red Hat Insights{' '}
+          <Icon className="pf-v5-u-ml-xs">
+            <ExternalLinkAltIcon />
+          </Icon>
+        </a>
+      </Text>
+    </TextContent>
+  );
+};
+
+export default RegAssistantFooter;

--- a/src/Components/RegistrationProgress/RegProgressStepper.js
+++ b/src/Components/RegistrationProgress/RegProgressStepper.js
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { ProgressStep, ProgressStepper } from '@patternfly/react-core';
+import FirstStep from './FirstStep';
+import SecondStep from './SecondStep';
+import ThirdStep from './ThirdStep';
+import FourthStep from './FourthStep';
+import RegAssistantFooter from './RegAssistantFooter';
+
+const RegProgessStepper = () => {
+  const [step, setStep] = useState(0);
+  const [selectedKey, setSelectedKey] = useState('Select activation key');
+  const [operatingSystem, setOperatingSystem] = useState();
+
+  const setVariant = (value) => {
+    if (step === value) {
+      return 'info';
+    } else if (step > value) {
+      return 'success';
+    } else if (step < value) {
+      return 'default';
+    }
+  };
+
+  return (
+    <React.Fragment>
+      <ProgressStepper isVertical>
+        <ProgressStep
+          isCurrent={step === 0}
+          description={
+            <FirstStep
+              selectedKey={selectedKey}
+              setSelectedKey={setSelectedKey}
+              setStep={setStep}
+              step={step}
+            />
+          }
+          variant={setVariant(0)}
+        >
+          Select activation key
+        </ProgressStep>
+        <ProgressStep
+          isCurrent={step === 1}
+          variant={setVariant(1)}
+          description={
+            step >= 1 && (
+              <SecondStep
+                operatingSystem={operatingSystem}
+                setOperatingSystem={setOperatingSystem}
+                setStep={setStep}
+              />
+            )
+          }
+        >
+          {step >= 1 && 'Select operating system'}
+        </ProgressStep>
+        <ProgressStep
+          isCurrent={step === 2}
+          variant={setVariant(2)}
+          description={
+            step >= 2 && (
+              <ThirdStep
+                OperatingSystemComponent={operatingSystem.content}
+                selectedKey={selectedKey}
+              />
+            )
+          }
+        >
+          {step >= 2 && `Register ${operatingSystem.name}`}
+        </ProgressStep>
+        <ProgressStep
+          isCurrent={step === 3}
+          variant={setVariant(3)}
+          description={
+            step >= 2 && <FourthStep setStep={setStep} step={step} />
+          }
+        >
+          {step >= 2 && 'View registered system'}
+        </ProgressStep>
+      </ProgressStepper>
+      {step >= 2 && <RegAssistantFooter />}
+    </React.Fragment>
+  );
+};
+
+export default RegProgessStepper;

--- a/src/Components/RegistrationProgress/SecondStep.js
+++ b/src/Components/RegistrationProgress/SecondStep.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Flex,
+  FlexItem,
+  Radio,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+import { operatingSystemList } from './operatingSystemConstants';
+
+const SecondStep = ({ operatingSystem, setOperatingSystem, setStep }) => {
+  const handleOperatingSystemSelect = (os) => {
+    setOperatingSystem(os);
+    setStep(2);
+  };
+
+  return (
+    <React.Fragment>
+      <TextContent>
+        <Text component={TextVariants.p}>
+          Select the OS your system is running.
+        </Text>
+        <Flex>
+          {operatingSystemList.map((os) => (
+            <FlexItem spacer={{ default: 'spacerMd' }} key={`${os.name}-radio`}>
+              <Radio
+                isChecked={operatingSystem?.name === os.name}
+                name={os.name}
+                onChange={() => handleOperatingSystemSelect(os)}
+                label={os.name}
+                id={os.id}
+              />
+            </FlexItem>
+          ))}
+        </Flex>
+      </TextContent>
+    </React.Fragment>
+  );
+};
+
+SecondStep.propTypes = {
+  operatingSystem: PropTypes.object,
+  setOperatingSystem: PropTypes.func,
+  setStep: PropTypes.func,
+  step: PropTypes.number,
+};
+
+export default SecondStep;

--- a/src/Components/RegistrationProgress/ThirdStep.js
+++ b/src/Components/RegistrationProgress/ThirdStep.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ThirdStep = ({ OperatingSystemComponent, selectedKey }) => {
+  return (
+    <React.Fragment>
+      {<OperatingSystemComponent selectedKey={selectedKey} />}
+    </React.Fragment>
+  );
+};
+
+ThirdStep.propTypes = {
+  OperatingSystemComponent: PropTypes.node,
+  selectedKey: PropTypes.string,
+};
+
+export default ThirdStep;

--- a/src/Components/RegistrationProgress/__tests__/RegProgressStepper.test.js
+++ b/src/Components/RegistrationProgress/__tests__/RegProgressStepper.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import RegProgessStepper from '../RegProgressStepper';
+
+describe('RegProgressStepper', () => {
+  it('should step through the progress stepper', async () => {
+    render(
+      <Router>
+        <RegProgessStepper />
+      </Router>
+    );
+
+    expect(screen.getByTestId('select-activation-key')).toBeTruthy();
+    expect(screen.queryByText(/select operating system/i)).toBeFalsy();
+
+    await waitFor(() =>
+      userEvent.click(
+        screen.getByRole('button', {
+          name: /select activation key/i,
+        })
+      )
+    );
+
+    await waitFor(() =>
+      userEvent.click(
+        screen.getByRole('option', {
+          name: /activation-key-1/i,
+        })
+      )
+    );
+
+    expect(screen.getByText(/select operating system/i)).toBeVisible();
+    expect(screen.queryByText(/register rhel 8/i)).toBeFalsy();
+    expect(screen.queryByText(/view registered system/i)).toBeFalsy();
+
+    await waitFor(() =>
+      userEvent.click(
+        screen.getByRole('radio', {
+          name: /rhel 8/i,
+        })
+      )
+    );
+
+    expect(screen.getByText(/register rhel 8/i)).toBeVisible();
+    expect(screen.getByText(/view registered system/i)).toBeVisible();
+  });
+});

--- a/src/Components/RegistrationProgress/operatingSystemConstants.js
+++ b/src/Components/RegistrationProgress/operatingSystemConstants.js
@@ -1,0 +1,27 @@
+import CentosLinuxRegContent from './CentosLinuxRegContent';
+import RHEL8RegContent from './RHEL8RegContent';
+import RHEL7RegContent from './RHEL7RegContent';
+import RHEL9RegContent from './RHEL9RegContent';
+
+export const operatingSystemList = [
+  {
+    id: 'centos-radio',
+    name: 'CentOS Linux',
+    content: CentosLinuxRegContent,
+  },
+  {
+    id: 'rhel7-radio',
+    name: 'RHEL 7',
+    content: RHEL7RegContent,
+  },
+  {
+    id: 'rhel8-radio',
+    name: 'RHEL 8',
+    content: RHEL8RegContent,
+  },
+  {
+    id: 'rhel9-radio',
+    name: 'RHEL 9 or later',
+    content: RHEL9RegContent,
+  },
+];

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,13 +2,21 @@ import React, { Suspense, lazy } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import Loading from './Components/Loading/Loading';
+import { useRefreshFeatureFlag } from './Utilities/Hooks';
 
 const Register = lazy(() =>
   import(/* webpackChunkName: "Register" */ './Routes/Register/Register')
 );
+
+const NewRegister = lazy(() =>
+  import(/* webpackChunkName: "Register" */ './Routes/Register/NewRegister')
+);
+
 const paths = { register: '/' };
 
 export const RouteList = () => {
+  const isRefreshEnabled = useRefreshFeatureFlag();
+
   return (
     <Routes>
       <Route
@@ -19,7 +27,7 @@ export const RouteList = () => {
         element={
           <Suspense fallback={<Loading />}>
             {' '}
-            <Register />{' '}
+            {isRefreshEnabled ? <NewRegister /> : <Register />}{' '}
           </Suspense>
         }
       />

--- a/src/Routes/Register/NewRegister.js
+++ b/src/Routes/Register/NewRegister.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import {
+  Icon,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
+import {
+  dataCollection,
+  dataCollectionLink,
+  regAssistantDescription,
+} from '../../constants';
+import {
+  PageHeader,
+  PageHeaderTitle,
+} from '@redhat-cloud-services/frontend-components/PageHeader';
+import RegProgessStepper from '../../Components/RegistrationProgress/RegProgressStepper';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const NewRegister = () => {
+  return (
+    <React.Fragment>
+      <Helmet>
+        <meta charSet="utf-8" />
+        <title>Register Systems | RHEL</title>
+      </Helmet>
+      <PageHeader>
+        <PageHeaderTitle
+          style={{ paddingBottom: '16px' }}
+          title="Registration Assistant"
+        />
+        <TextContent>
+          <Text>{regAssistantDescription}</Text>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href={dataCollectionLink}
+          >
+            {dataCollection}
+            <Icon className="pf-v5-u-ml-xs">
+              <ExternalLinkAltIcon />
+            </Icon>
+          </a>
+        </TextContent>
+      </PageHeader>
+      <PageSection
+        className="ins-c-registration-assistant ins-c-overflow-content"
+        variant={PageSectionVariants.light}
+      >
+        <RegProgessStepper />
+      </PageSection>
+    </React.Fragment>
+  );
+};
+
+export default NewRegister;

--- a/src/Utilities/Hooks.js
+++ b/src/Utilities/Hooks.js
@@ -1,0 +1,10 @@
+import { useFlag, useFlagsStatus } from '@unleash/proxy-client-react';
+
+export const useFeatureFlag = (flag) => {
+  const { flagsReady } = useFlagsStatus();
+  const isFlagEnabled = useFlag(flag);
+  return flagsReady ? isFlagEnabled : undefined;
+};
+
+export const useRefreshFeatureFlag = () =>
+  useFeatureFlag('registration-assistant-refresh');

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,14 @@
+export const regAssistantDescription =
+  'The Insights for RHEL registration assistant will guide you through the setup process for the Red Hat Insights client.';
+
+export const dataCollection =
+  "Learn more about Red Hat Insights' data collection and controls";
+
+export const dataCollectionLink =
+  'https://www.redhat.com/en/technologies/management/insights/data-application-security#section-data-collection';
+
+export const remoteHostConfigLink =
+  'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/remote_host_configuration_and_management/index';
+
+export const monitoringHostsLink =
+  'https://docs.redhat.com/en/documentation/red_hat_satellite/6.14/html/managing_hosts/Monitoring_Hosts_Using_Red_Hat_Insights_managing-hosts#deploying-red-hat-insights-using-the-ansible-role_managing-hosts';


### PR DESCRIPTION
As part of registration assistant refresh, this PR implements the ProgressStepper and some individual step features.

It does not include actual activation key data or content for the selected OS; but it does include the data necessary to step through the stepper.

To test, replace `<Register />` in `Routes.js` with `<NewRegister />` and uncomment the lazy loaded `NewRegister` component in the same file. Run the app and you should see the new content.

Refer to the mocks in the Jira card for specific design.