### PR TITLE
fix(RHINENG-15285): Update links for Centos registration

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -39,9 +39,9 @@ export const insightsClientRegister = 'insights-client --register';
 
 export const yumInstallInsightsClient = 'yum install insights-client';
 
-export const centosInstallRHC = `curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://www.redhat.com/security/data/fd431d51.txt
+export const centosInstallRHC = `curl -o /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release https://security.access.redhat.com/data/fd431d51.txt
 
-curl -o /etc/yum.repos.d/client-tools-for-rhel-7-server.repo https://ftp.redhat.com/redhat/client-tools/client-tools-for-rhel-7-server.repo
+curl -o /etc/yum.repos.d/client-tools-for-rhel-7-server.repo https://cdn-public.redhat.com/content/public/repofiles/client-tools-for-rhel-7-server.repo
 
 sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*.repo
 sed -i 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=http://vault.centos.org/7.9.2009|g' /etc/yum.repos.d/CentOS-*.repo


### PR DESCRIPTION
To test:
- go to registration assistant
- pick or create an activation key
- select CentOS Linux 7

See the links for the 2 curl commands. Those links have been updated according to the Jira card.