### PR TITLE
fix(RHINENG-18539): Activation keys empty state

### DIFF
--- a/src/Components/RegistrationProgress/RegProgressStepper.js
+++ b/src/Components/RegistrationProgress/RegProgressStepper.js
@@ -25,7 +25,7 @@ const RegProgessStepper = () => {
   const handleFetchKeys = async () => {
     const fetchedKeys = await fetchActivationKeys(axios);
 
-    if (fetchedKeys.body?.length) {
+    if (fetchedKeys.body) {
       const keysList = fetchedKeys.body.length
         ? fetchedKeys.body
         : emptyActivationKeys;

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,8 +5,8 @@ import {
 } from '@redhat-cloud-services/frontend-components/Skeleton';
 import {
   EmptyState,
+  EmptyStateBody,
   EmptyStateHeader,
-  EmptyStateIcon,
   EmptyStateVariant,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -92,11 +92,8 @@ export const emptyActivationKeys = [
   {
     name: (
       <EmptyState variant={EmptyStateVariant.xs}>
-        <EmptyStateHeader
-          titleText="No activation keys yet"
-          headingLevel="h6"
-          icon={<EmptyStateIcon icon={PlusCircleIcon} />}
-        />
+        <EmptyStateHeader icon={<PlusCircleIcon />} />
+        <EmptyStateBody>No activation keys yet</EmptyStateBody>
       </EmptyState>
     ),
     isDisabled: true,


### PR DESCRIPTION
We had a bad conditional for showing when a user has no activation keys. To test, go to Registration Assistant using an account with no activation keys (I can provide a login if you don't have one). Click the activation keys selection dropdown and wait for the fetch to complete.