### PR TITLE
chore: add analytics API keys to frontend deploy config

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -20,7 +20,14 @@ objects:
           - v1
       image: ${IMAGE}:${IMAGE_TAG}
       module:
+        analytics:
+          APIKey: apRCg9V6oMXCcnTingqRYW6m1er4hkCW
+          APIKeyDev: aMINBssUhXV1okzk7ZBaqwdTgtA0ySpg
         manifestLocation: /apps/registration/fed-mods.json
+        config:
+          supportCaseData:
+            product: Red Hat Insights
+            version: Registration Assistant
         modules:
           - id: registration
             module: ./RootApp


### PR DESCRIPTION
## Summary
- Adds the `analytics` block with `APIKey` and `APIKeyDev` to the `module` section in `deploy/frontend.yaml`
- Aligns with the pattern used by other frontends (inventory, advisor, tasks, ocp-advisor)

## Test plan
- [ ] Verify the YAML is valid and the deploy CRD parses correctly
- [ ] Confirm analytics events are sent in stage with the correct API key