### PR TITLE
chore(RHINENG-22650): Update inventory link verbiage

### DIFF
--- a/src/Components/RegistrationProgress/ViewInventoryStep.js
+++ b/src/Components/RegistrationProgress/ViewInventoryStep.js
@@ -11,7 +11,7 @@ const ViewInventoryStep = () => {
             <span>
               Navigate to the{' '}
               <InsightsLink to="/" app="inventory">
-                Inventory page
+                Systems Inventory page
               </InsightsLink>
             </span>
             <br />


### PR DESCRIPTION
With more and more inventories being present in HCC, it was suggested to specify which of them users are redirected when clicking the links in Registration Assistant.

“Navigate to Inventory page…” should this be changed to “Navigate to Systems Inventory page”?

<img width="532" height="842" alt="image" src="https://github.com/user-attachments/assets/4a09e898-e7c3-4569-8992-1ed5d49a7809" />