### PR TITLE
fix(CI): add codecov action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,10 @@ jobs:
         if: github.event_name == 'pull_request'
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - run: npm run ci:verify
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: true
+          files: ./coverage/coverage-final.json,./coverage-jest/coverage-final.json,./coverage-cypress/coverage-final.json
+          token: ${{ secrets.CODECOV_TOKEN }}
       - run: npm run build


### PR DESCRIPTION
ci:verify script was taking care of uploading coverage before, but it got broken because of outdated codecov cli. To avoid such issues in the future, we better use upload codecov action which is supported

